### PR TITLE
tablesAccess indicates that table was accessed for DROP DATABASE

### DIFF
--- a/include/sqlparser/DropStatement.h
+++ b/include/sqlparser/DropStatement.h
@@ -21,7 +21,7 @@ namespace hsql {
     DropStatement(DropType type);
     virtual ~DropStatement();
       void tablesAccessed(TableAccessMap& accessMap) const override {
-        if (name != nullptr) {
+        if ((name != nullptr) && (type == kDropTable)) {
             TableAccess::addOperation(accessMap, name, schema, TableAccess::OpDrop);
         }
       };


### PR DESCRIPTION
The issue is that for statement:
DROP DATABASE testdb;
tablesAccessed returned that table testdb was accessed.

DropStatement::tablesAccessed does not check the type of drop operation and returns that table was accessed for all drop operations (database, index, view, etc). This fix checks that drop was for table only.
